### PR TITLE
feat: Add Streamable HTTP transport & Docker support 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Git
+.git
+.gitignore
+.github
+
+# Documentation
+README.md
+*.md
+LICENSE
+
+# Build artifacts (keep only linux-amd64 binary)
+bin/openplantbook-mcp-darwin-*
+bin/openplantbook-mcp-windows-*
+bin/*.mcpb
+
+# Go build artifacts
+*.out
+coverage.html
+coverage.out
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# Testing
+*_test.go
+testdata
+
+# MCPB artifacts (not needed for Docker)
+mcpb/
+
+# Examples
+examples/
+
+# CI/CD
+.github/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,9 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - name: Checkout code
@@ -141,17 +144,18 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to DockerHub
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ secrets.DOCKERHUB_USERNAME }}/openplantbook-mcp
+        images: ghcr.io/${{ github.repository }}
         tags: |
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,11 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: Release
+  build:
+    name: Build Binaries
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
     - name: Checkout code
@@ -28,6 +30,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
+
+    - name: Extract version
+      id: version
+      run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
     - name: Install MCPB
       run: npm install -g @anthropic-ai/mcpb
@@ -47,6 +53,13 @@ jobs:
         cd bin
         sha256sum openplantbook-mcp-* > SHA256SUMS
         cat SHA256SUMS
+
+    - name: Upload Linux binary for Docker
+      uses: actions/upload-artifact@v5
+      with:
+        name: linux-binary
+        path: bin/openplantbook-mcp-linux-amd64
+        retention-days: 1
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
@@ -106,3 +119,52 @@ jobs:
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download Linux binary
+      uses: actions/download-artifact@v5
+      with:
+        name: linux-binary
+        path: bin/
+
+    - name: Make binary executable
+      run: chmod +x bin/openplantbook-mcp-linux-amd64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ secrets.DOCKERHUB_USERNAME }}/openplantbook-mcp
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Dockerfile for OpenPlantbook MCP Server with MCPO proxy
+# This wraps the MCP server with MCPO to expose it as REST/OpenAPI for OpenWebUI
+FROM ghcr.io/open-webui/mcpo:main AS base
+
+# Install any additional dependencies if needed
+# The mcpo image already has Python and mcpo installed
+
+# Copy the pre-compiled Linux binary
+COPY bin/openplantbook-mcp-linux-amd64 /usr/local/bin/openplantbook-mcp
+RUN chmod +x /usr/local/bin/openplantbook-mcp
+
+# Expose the MCPO HTTP port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8000/health || exit 1
+
+# Run MCPO with the openplantbook-mcp server
+# Environment variables will be passed through to the MCP server:
+# - OPENPLANTBOOK_API_KEY
+# - OPENPLANTBOOK_LOG_LEVEL
+# - OPENPLANTBOOK_LOG_FILE
+# - etc.
+ENTRYPOINT ["mcpo"]
+CMD ["--", "/usr/local/bin/openplantbook-mcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,29 @@
-# Dockerfile for OpenPlantbook MCP Server with MCPO proxy
-# This wraps the MCP server with MCPO to expose it as REST/OpenAPI for OpenWebUI
-FROM ghcr.io/open-webui/mcpo:main AS base
+# Dockerfile for OpenPlantbook MCP Server with native Streamable HTTP transport
+# This exposes MCP directly over HTTP (no MCPO needed)
+FROM debian:bookworm-slim
 
-# Install any additional dependencies if needed
-# The mcpo image already has Python and mcpo installed
+# Install ca-certificates for HTTPS requests
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the pre-compiled Linux binary
 COPY bin/openplantbook-mcp-linux-amd64 /usr/local/bin/openplantbook-mcp
 RUN chmod +x /usr/local/bin/openplantbook-mcp
 
-# Expose the MCPO HTTP port
+# Expose the MCP HTTP port
 EXPOSE 8000
 
-# Health check
+# Health check (MCP endpoint is at /mcp)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8000/health || exit 1
+  CMD test -f /proc/1/cmdline || exit 1
 
-# Run MCPO with the openplantbook-mcp server
-# Environment variables will be passed through to the MCP server:
-# - OPENPLANTBOOK_API_KEY
-# - OPENPLANTBOOK_LOG_LEVEL
-# - OPENPLANTBOOK_LOG_FILE
-# - etc.
-ENTRYPOINT ["mcpo"]
-CMD ["--", "/usr/local/bin/openplantbook-mcp"]
+# Environment variables:
+# - OPENPLANTBOOK_API_KEY (required)
+# - OPENPLANTBOOK_LOG_LEVEL (optional, default: info)
+# - OPENPLANTBOOK_CACHE_ENABLED (optional, default: true)
+# - OPENPLANTBOOK_CACHE_TTL_HOURS (optional, default: 24)
+
+# Run MCP server in HTTP mode
+ENTRYPOINT ["/usr/local/bin/openplantbook-mcp"]
+CMD ["--http", "--port", "8000"]


### PR DESCRIPTION
Hi! First off, thanks for creating this MCP server. My wife recently got into plants and gardening, so I wanted to bring plant care info into our AI tools.

I use OpenWebUI and LiteLLM on my Kubernetes cluster, which meant I needed Docker support and HTTP transport instead of just stdio. So I added:

  - --http and --port flags to enable Streamable HTTP mode
  - Docker image that exposes native MCP (no proxy needed)
  - Backward compatibility - stdio remains the default for Claude Desktop

Everything's tested and working with both LiteLLM and OpenWebUI.

Usage
```
# stdio mode (default - Claude Desktop/Code)
./openplantbook-mcp

# HTTP mode (LiteLLM/OpenWebUI)
./openplantbook-mcp --http --port 8000
```
Disclosure: Claude Code helped me write this implementation.

Let me know if you'd like any changes!